### PR TITLE
## Fix ETL Layer Get Schema Errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0",
-                "@tak-ps/etl": "^9.9.0",
+                "@tak-ps/etl": "^9.22.0",
                 "cheerio": "^1.0.0-rc.12"
             },
             "devDependencies": {
@@ -1691,9 +1691,9 @@
             }
         },
         "node_modules/@tak-ps/etl": {
-            "version": "9.20.0",
-            "resolved": "https://registry.npmjs.org/@tak-ps/etl/-/etl-9.20.0.tgz",
-            "integrity": "sha512-5U938sEFhK5Zz0GG3px2arHC+37XCduDSpVXOFj13GH4Z0/mYF8U6BpXebjc4shh14vjYhz843effJLDOWE3Mg==",
+            "version": "9.24.0",
+            "resolved": "https://registry.npmjs.org/@tak-ps/etl/-/etl-9.24.0.tgz",
+            "integrity": "sha512-6SjpNJcbhYiRrgyfBjbCO1pxZGnlGbSoXjkxwAcdSDV7VvTOR4oYiMlCo0/EUZbL3fHTyYviadve6WJlrWHNFQ==",
             "license": "ISC",
             "dependencies": {
                 "@aws-sdk/client-secrets-manager": "^3.828.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "@sinclair/typebox": "^0.34.0",
-        "@tak-ps/etl": "^9.9.0",
+        "@tak-ps/etl": "^9.22.0",
         "cheerio": "^1.0.0-rc.12"
     }
 }


### PR DESCRIPTION
Updates `@tak-ps/etl` dependency from version 9.9.0 to 9.22.0 to resolve schema errors in ETL Layer Get operations.

### Changes
- Updated `@tak-ps/etl` dependency to `^9.22.0` in package.json

### Why
ETLs using versions below 9.22.0 are experiencing schema validation failures when performing Layer Get operations. This update ensures compatibility with the current ETL API schema requirements.